### PR TITLE
Fix cwd, paths

### DIFF
--- a/cmd/tsgolint/main.go
+++ b/cmd/tsgolint/main.go
@@ -263,6 +263,7 @@ func runMain() int {
 		fmt.Fprintf(os.Stderr, "error getting current directory: %v\n", err)
 		return 1
 	}
+	currentDirectory = tspath.NormalizePath(currentDirectory)
 
 	fs := bundled.WrapFS(osvfs.FS())
 	var configFileName string
@@ -280,6 +281,8 @@ func runMain() int {
 			return 1
 		}
 	}
+
+	currentDirectory = tspath.GetDirectoryPath(configFileName)
 
 	var rules = []rule.Rule{
 		await_thenable.AwaitThenableRule,


### PR DESCRIPTION
Paths that come from `os` and `filepath` can't be passed into TS without normalization, so fix `Getwd`'s output.

The current directory was also not changing to the config path's dir, so later checks about path prefixes weren't working.